### PR TITLE
Add Influxdb to docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-StatsD + Graphite + Grafana 2 + Kamon Dashboards
+StatsD + Graphite + Influxdb + Grafana 2 + Kamon Dashboards
 ---------------------------------------------
 
-This image contains a sensible default configuration of StatsD, Graphite and Grafana, and comes bundled with a example
+This image contains a sensible default configuration of Influxdb, StatsD, Graphite and Grafana, and comes bundled with a example
 dashboard that gives you the basic metrics currently collected by Kamon for both Actors and Traces. There are two ways
 for using this image:
 
@@ -17,7 +17,8 @@ need as a prerequisite is having `docker`, `docker-compose`, and `make` installe
 - `2004`: the Graphite pickled stats publication port
 - `8125`: the StatsD port.
 - `8126`: the StatsD administrative port.
-
+- `8083`: the Influxdb administrative port.
+- `8086`: the Influxdb stats publication port
 To start a container with this image you just need to run the following command:
 
 ```bash
@@ -48,6 +49,11 @@ ports to whatever you want by changing left side number in the `--publish` param
 The Dockerfile and supporting configuration files are available in our [Github repository](https://github.com/kamon-io/docker-grafana-graphite).
 This comes specially handy if you want to change any of the StatsD, Graphite or Grafana settings, or simply if you want
 to know how tha image was built. The repo also has `build` and `start` scripts to make your workflow more pleasant.
+
+### Using the Influxdb ###
+
+If you want to post stats to Influxdb, you need to create a database in Influxdb before posting any stats. You can access to http://influxdb.host.com:8083 administrative page, to create database, 
+the database name will be used in Influxdb client's configuration. 
 
 
 ### Using the Dashboards ###

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,14 +2,18 @@ version: '2'
 services:
   grafana_graphite:
     build: .
-    image: kamon/grafana_graphite
-    container_name: kamon-grafana-dashboard
+    image: graphite-statsd-influxdb
+    container_name: graphite-statsd-influxdb
     ports:
       - '80:80'
       - '81:81'
+      - '2003:2003'
       - '8125:8125/udp'
       - '8126:8126'
+      - '8086:8086'
+      - '8083:8083'
     volumes:
-      - ./data/whisper:/opt/graphite/storage/whisper
-      - ./data/grafana:/opt/grafana/data
-      - ./log/graphite:/opt/graphite/storage/log
+      - ./docker-share/data/whisper:/opt/graphite/storage/whisper
+      - ./docker-share/data/grafana:/opt/grafana/data
+      - ./docker-share/log/graphite:/opt/graphite/storage/log
+      - ./docker-share/influxdb:/var/lib/influxdb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - '8086:8086'
       - '8083:8083'
     volumes:
-      - ./docker-share/data/whisper:/opt/graphite/storage/whisper
-      - ./docker-share/data/grafana:/opt/grafana/data
-      - ./docker-share/log/graphite:/opt/graphite/storage/log
-      - ./docker-share/influxdb:/var/lib/influxdb
+      - ./data/whisper:/opt/graphite/storage/whisper
+      - ./data/grafana:/opt/grafana/data
+      - ./log/graphite:/opt/graphite/storage/log
+      - ./data/influxdb:/var/lib/influxdb

--- a/influxdb/influxdb.conf
+++ b/influxdb/influxdb.conf
@@ -1,0 +1,129 @@
+reporting-disabled = false
+bind-address = ":8088"
+
+[meta]
+  dir = "/var/lib/influxdb/meta"
+  retention-autocreate = true
+  logging-enabled = true
+
+[data]
+  dir = "/var/lib/influxdb/data"
+  wal-dir = "/var/lib/influxdb/wal"
+  query-log-enabled = true
+  cache-max-memory-size = 1073741824
+  cache-snapshot-memory-size = 26214400
+  cache-snapshot-write-cold-duration = "10m0s"
+  compact-full-write-cold-duration = "4h0m0s"
+  max-series-per-database = 1000000
+  max-values-per-tag = 100000
+  trace-logging-enabled = false
+
+[coordinator]
+  write-timeout = "10s"
+  max-concurrent-queries = 0
+  query-timeout = "0s"
+  log-queries-after = "0s"
+  max-select-point = 0
+  max-select-series = 0
+  max-select-buckets = 0
+
+[retention]
+  enabled = true
+  check-interval = "30m0s"
+
+[shard-precreation]
+  enabled = true
+  check-interval = "10m0s"
+  advance-period = "30m0s"
+
+[admin]
+  enabled = true
+  bind-address = ":8083"
+  https-enabled = false
+  https-certificate = "/etc/ssl/influxdb.pem"
+
+[monitor]
+  store-enabled = true
+  store-database = "_internal"
+  store-interval = "10s"
+
+[subscriber]
+  enabled = true
+  http-timeout = "30s"
+  insecure-skip-verify = false
+  ca-certs = ""
+  write-concurrency = 40
+  write-buffer-size = 1000
+
+[http]
+  enabled = true
+  bind-address = ":8086"
+  auth-enabled = false
+  log-enabled = true
+  write-tracing = false
+  pprof-enabled = true
+  https-enabled = false
+  https-certificate = "/etc/ssl/influxdb.pem"
+  https-private-key = ""
+  max-row-limit = 10000
+  max-connection-limit = 0
+  shared-secret = ""
+  realm = "InfluxDB"
+  unix-socket-enabled = false
+  bind-socket = "/var/run/influxdb.sock"
+
+[[graphite]]
+  enabled = false
+  bind-address = ":2003"
+  database = "graphite"
+  retention-policy = ""
+  protocol = "tcp"
+  batch-size = 5000
+  batch-pending = 10
+  batch-timeout = "1s"
+  consistency-level = "one"
+  separator = "."
+  udp-read-buffer = 0
+
+[[collectd]]
+  enabled = false
+  bind-address = ":25826"
+  database = "collectd"
+  retention-policy = ""
+  batch-size = 5000
+  batch-pending = 10
+  batch-timeout = "10s"
+  read-buffer = 0
+  typesdb = "/usr/share/collectd/types.db"
+  security-level = "none"
+  auth-file = "/etc/collectd/auth_file"
+
+[[opentsdb]]
+  enabled = false
+  bind-address = ":4242"
+  database = "opentsdb"
+  retention-policy = ""
+  consistency-level = "one"
+  tls-enabled = false
+  certificate = "/etc/ssl/influxdb.pem"
+  batch-size = 1000
+  batch-pending = 5
+  batch-timeout = "1s"
+  log-point-errors = true
+
+[[udp]]
+  enabled = false
+  bind-address = ":8089"
+  database = "udp"
+  retention-policy = ""
+  batch-size = 5000
+  batch-pending = 10
+  read-buffer = 0
+  batch-timeout = "1s"
+  precision = ""
+
+[continuous_queries]
+  log-enabled = true
+  enabled = true
+  run-interval = "1s"
+

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -8,6 +8,12 @@ stdout_logfile = /var/log/supervisor/%(program_name)s.log
 stderr_logfile = /var/log/supervisor/%(program_name)s.log
 autorestart = true
 
+[program:influxdb]
+command = /usr/bin/influxd -pidfile /var/run/influxdb/influxd.pid -config /etc/influxdb/influxdb.conf 
+stdout_logfile = /var/log/supervisor/%(program_name)s.log
+stderr_logfile = /var/log/supervisor/%(program_name)s.log
+autorestart = true
+
 [program:carbon-cache]
 ;user = www-data
 command = /opt/graphite/bin/carbon-cache.py --pidfile /var/run/carbon-cache-a.pid --debug start
@@ -48,3 +54,4 @@ stderr_logfile = /var/log/supervisor/%(program_name)s.log
 exitcodes = 0
 autorestart = unexpected
 startretries = 3
+


### PR DESCRIPTION
1. Changed README.md to add ports for Influxdb and how to create a database in it.
2. Changed the Dockerfile to add the Influxdb image 1.2.0 (which is the latest release version).
3. Add a new configuration file for Influxdb. 
4. Changed the supervisord.conf file to add scripts of how to start the Influxdb when docker container is started. 
5. Changed docker-compose.yml to add new ports for Influxdb and the database's data file directory.